### PR TITLE
Fix example syntax error

### DIFF
--- a/Custom_Vision/Object_detection.py
+++ b/Custom_Vision/Object_detection.py
@@ -77,7 +77,7 @@ scissors_image_regions = {
 }
 
 # Update this with the path to where you downloaded the images.
-base_image_location = "<path to directory"
+base_image_location = "<path to directory>"
 
 # Go through the data table above and create the images
 print("Adding images...")


### PR DESCRIPTION
## Summary
- fix syntax error in the Custom Vision object detection sample

## Testing
- `python -m py_compile Custom_Vision/Object_detection.py`

------
https://chatgpt.com/codex/tasks/task_e_6845e76ea8848320b583ffddf897fabe