### PR TITLE
PR1: Scaffold AI Onboarded with Next.js tooling baseline

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# App
+NODE_ENV=development
+NEXT_PUBLIC_SITE_URL=http://localhost:3000
+
+# Database
+DATABASE_URL=postgresql://postgres:postgres@db:5432/aionboarded
+
+# CMS (Payload) - PR2
+PAYLOAD_SECRET=replace-me
+PAYLOAD_PUBLIC_SERVER_URL=http://localhost:4000
+
+# Email provider (Resend) - PR4+
+RESEND_API_KEY=replace-me

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "extends": ["next/core-web-vitals", "next/typescript"],
+  "rules": {
+    "@next/next/no-html-link-for-pages": "off"
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  quality:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run test
+      - run: npm run build

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules
+.next
+coverage
+.env
+npm-debug.log*
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:20-alpine AS base
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+EXPOSE 3000
+CMD ["npm", "run", "dev"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,43 @@
-# AI102Files
+# AI Onboarded (aionboarded.ai)
 
-Files for my AI-102 course.
+Production-grade web platform for AI podcast episodes, newsletters, curated news, and long-form blog content.
 
-The course is available here: https://www.udemy.com/course/ai102-azure/
+## PR Workflow
+This repository is being delivered through planned PR increments:
+1. PR1: Scaffold + tooling ✅
+2. PR2: Payload CMS + schema + seed
+3. PR3: Public content pages
+4. PR4: Admin roles + draft/publish + media
+5. PR5: Search + RSS + SEO
+6. PR6: Security hardening + performance
+7. PR7: Deployment runbooks
 
+## Tech Stack
+- Next.js App Router + TypeScript + Tailwind CSS
+- PostgreSQL
+- Payload CMS (PR2)
+- Resend (PR4+)
+
+## Local Development
+1. Copy environment template:
+   ```bash
+   cp .env.example .env
+   ```
+2. Install dependencies:
+   ```bash
+   npm install
+   ```
+3. Start app and supporting services:
+   ```bash
+   docker compose up --build
+   ```
+4. Open `http://localhost:3000`.
+
+## Scripts
+- `npm run dev` - start Next.js dev server
+- `npm run lint` - run ESLint
+- `npm run test` - run Vitest test suite
+- `npm run build` - production build
+
+## Architecture
+See `docs/architecture.md` for route map, data model, security controls, and deployment plan.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,37 @@
+version: "3.9"
+
+services:
+  web:
+    build: .
+    ports:
+      - "3000:3000"
+    env_file:
+      - .env
+    volumes:
+      - ./:/app
+      - /app/node_modules
+    depends_on:
+      - db
+
+  db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: aionboarded
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+  cms:
+    image: node:20-alpine
+    working_dir: /workspace
+    command: sh -c "echo 'Payload CMS will be configured in PR2'; sleep infinity"
+    ports:
+      - "4000:4000"
+    depends_on:
+      - db
+
+volumes:
+  postgres_data:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,75 @@
+# AI Onboarded Architecture (v1)
+
+## Product Scope
+AI Onboarded (`aionboarded.ai`) is a content-driven publication platform with four primary streams: podcast episodes, newsletters, AI news updates, and long-form blog posts. The system includes public consumption surfaces and a secure editorial workflow.
+
+## Core Tech Choices
+- **Frontend/Web**: Next.js (App Router) + TypeScript + Tailwind CSS.
+- **CMS**: **Payload CMS (self-hosted)** for content modeling, media, RBAC, and draft/publish.
+- **Database**: PostgreSQL (shared by Payload and app-side indexed/search data).
+- **Email subscriptions**: **Resend** (transactional + newsletter opt-in workflows).
+- **Search**: Postgres full-text search (initial), optional Meilisearch/Algolia later.
+- **Testing/Quality**: ESLint, Prettier, Vitest + Testing Library, Playwright (later PR).
+- **Operations**: Docker Compose for local dev; GitHub Actions for CI.
+
+## Route Map (App Router)
+- `/` Home (latest from all sections + subscribe CTA)
+- `/podcast` + `/podcast/[slug]`
+- `/newsletter` + `/newsletter/[slug]`
+- `/news` + `/news/[slug]`
+- `/blog` + `/blog/[slug]`
+- `/search?q=`
+- `/about`, `/contact`
+- `/rss.xml` (combined or blog/podcast variants)
+- `/sitemap.xml`, `/robots.txt`
+
+## Data Model (Payload Collections)
+- `authors`: name, slug, bio, avatar, social links
+- `tags`: name, slug, type
+- `pages`: title, slug, body, seo
+- `podcastEpisodes`: title, slug, summary, publishDate, audioUrl, showNotes, transcript, tags, seo, status
+- `newsletterIssues`: title, slug, issueNumber, publishDate, summary, body, cta, tags, seo, status
+- `newsItems`: title, slug, summary, body, sourceUrl, sourceName, publishDate, tags, seo, status
+- `blogPosts`: title, slug, excerpt, body, coverImage, author, categories/tags, publishDate, seo, status
+- `media`: Payload upload collection for images/audio assets
+- `subscribers` (optional collection for local tracking + Resend sync metadata)
+
+Shared fields: `slug`, `status` (`draft|published`), `publishedAt`, `seo` (meta title/description/OG image), and audit timestamps.
+
+## Security & Compliance Baseline
+- RBAC roles: `admin`, `editor` (least privilege).
+- HTTP security headers via Next config/middleware.
+- Input validation (Zod) on contact/subscribe/search APIs.
+- Rate limiting for forms/auth endpoints.
+- Sanitize rich content output and enforce CSP-safe rendering.
+- Strict env handling (`.env.example`, server-only secrets, startup validation).
+
+## SEO / Discovery
+- Per-route metadata API.
+- OpenGraph + Twitter card support.
+- JSON-LD structured data (Article, PodcastEpisode, Organization).
+- XML sitemap + robots policy.
+- RSS feeds (blog and podcast at minimum).
+
+## Deployment Plan
+### Hostinger (primary)
+1. Provision Hostinger Node.js Web App + managed PostgreSQL.
+2. Build artifact on CI (`next build`) and deploy via Git or SSH pipeline.
+3. Run Payload CMS and Next app as separate Node services (or monorepo process manager).
+4. Configure environment variables in Hostinger panel.
+5. Add reverse proxy routing (`/admin` to Payload, site routes to Next if split).
+6. Enable TLS and domain (`aionboarded.ai`).
+
+### Alternative: Vercel
+- Deploy Next app on Vercel.
+- Host Payload separately (Railway/Fly/Render) with Postgres.
+- Connect via secure API URL and webhooks for revalidation.
+
+## PR Plan
+1. **PR1**: Scaffold & tooling (Next/Tailwind/TS, lint/tests, Docker Compose, env template, CI)
+2. **PR2**: Payload CMS setup, collections/schema, DB integration, seed data
+3. **PR3**: Public page implementation (home, blog/news/newsletter/podcast)
+4. **PR4**: Admin RBAC, draft/publish workflow, media uploads/optimization
+5. **PR5**: Search, RSS, SEO outputs
+6. **PR6**: Security hardening + performance pass
+7. **PR7**: Deployment runbooks (Hostinger + alternative)

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,4 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,0 +1,21 @@
+import type { NextConfig } from "next";
+
+const securityHeaders = [
+  { key: "X-Frame-Options", value: "DENY" },
+  { key: "X-Content-Type-Options", value: "nosniff" },
+  { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+  { key: "Permissions-Policy", value: "camera=(), microphone=(), geolocation=()" }
+];
+
+const nextConfig: NextConfig = {
+  async headers() {
+    return [
+      {
+        source: "/(.*)",
+        headers: securityHeaders
+      }
+    ];
+  }
+};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "aionboarded",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "next": "14.2.5",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.10",
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "autoprefixer": "^10.4.19",
+    "eslint": "^8.57.0",
+    "eslint-config-next": "14.2.5",
+    "postcss": "^8.4.39",
+    "tailwindcss": "^3.4.7",
+    "typescript": "^5.5.3",
+    "vitest": "^2.0.3"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,0 +1,11 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: light;
+}
+
+body {
+  @apply bg-white text-slate-900 antialiased;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,17 @@
+import type { Metadata } from "next";
+import "./globals.css";
+
+export const metadata: Metadata = {
+  title: "AI Onboarded",
+  description: "AI news, podcast episodes, newsletters, and blog posts."
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        <main className="mx-auto min-h-screen max-w-5xl px-6 py-12">{children}</main>
+      </body>
+    </html>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,12 @@
+export default function HomePage() {
+  return (
+    <section className="space-y-4">
+      <p className="text-sm font-semibold uppercase tracking-wide text-brand">AI Onboarded</p>
+      <h1 className="text-4xl font-bold tracking-tight">Production-grade content platform scaffolding</h1>
+      <p className="max-w-2xl text-slate-600">
+        PR1 initializes the Next.js + TypeScript + Tailwind foundation with testing, CI, Docker Compose,
+        and environment templates.
+      </p>
+    </section>
+  );
+}

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -1,0 +1,5 @@
+export const siteName = "AI Onboarded";
+
+export function buildTitle(pageTitle: string): string {
+  return `${pageTitle} | ${siteName}`;
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,15 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  content: ["./src/**/*.{js,ts,jsx,tsx,mdx}"],
+  theme: {
+    extend: {
+      colors: {
+        brand: "#2563eb"
+      }
+    }
+  },
+  plugins: []
+};
+
+export default config;

--- a/tests/site.test.ts
+++ b/tests/site.test.ts
@@ -1,0 +1,7 @@
+import { buildTitle } from "@/lib/site";
+
+describe("buildTitle", () => {
+  it("appends site name", () => {
+    expect(buildTitle("Home")).toBe("Home | AI Onboarded");
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["DOM", "DOM.Iterable", "ES2022"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,14 @@
+import path from "node:path";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src")
+    }
+  },
+  test: {
+    environment: "node",
+    include: ["tests/**/*.test.ts?(x)"]
+  }
+});


### PR DESCRIPTION
### Motivation
- Establish a clear architecture and execution roadmap before implementing features so subsequent PRs can focus on CMS, content types, and public pages.
- Provide a production-ready foundation (Next.js + TypeScript + Tailwind, Postgres, Payload CMS choice, Resend for email) and local/dev infrastructure to iterate safely.

### Description
- Added an architecture/design document at `docs/architecture.md` that defines routes, data model, security baseline, and deployment plans (Hostinger primary, Vercel alternative).
- Scaffolded a Next.js App Router project with TypeScript and Tailwind including `src/app/layout.tsx`, `src/app/page.tsx`, `src/app/globals.css`, `src/lib/site.ts`, `tsconfig.json`, `tailwind.config.ts`, and `postcss.config.js`.
- Added project config and tooling: `package.json` scripts, `next.config.ts` with security headers, `.eslintrc.json`, `vitest.config.ts`, `tests/site.test.ts`, and a small unit helper test.
- Added local/dev infra: `Dockerfile`, `docker-compose.yml` with `web`, `db` (Postgres), and a placeholder `cms` service for PR2, plus `.env.example` and updated `README.md` for onboarding.
- Added CI baseline at `.github/workflows/ci.yml` to run `npm ci`, `npm run lint`, `npm run test`, and `npm run build` on push/PR.

### Testing
- Attempted to install dependencies with `npm install` and run local checks, but `npm install` failed due to npm registry access returning HTTP 403 in this environment so test execution was blocked.
- A Playwright screenshot attempt to `http://127.0.0.1:3000` failed with `ERR_EMPTY_RESPONSE` because the dev server could not be started without installing dependencies.
- Unit test scaffolding was added (`tests/site.test.ts`) and test runner configured via `vitest.config.ts`, and the CI workflow is configured to run `npm ci` and `npm run test` (these steps were not executed successfully in this environment).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699efef028148320aea93057660eb530)